### PR TITLE
T5 UE and UF unique plating

### DIFF
--- a/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Defense].xml
+++ b/Endless Space Competitive Mod/Simulation/Battles/ModuleDefinitions[Defense].xml
@@ -60,7 +60,7 @@
     <CategorizedSimulationDescriptors Category="CategoryDefenseHull"> </CategorizedSimulationDescriptors>
   </DefenseModule>
 
-  <DefenseModule Name="ModuleDefenseHullPlating4Terrans" Family="HullPlatingBase" Level="4">
+  <DefenseModule Name="ModuleDefenseHullPlating4Terrans" Family="HullPlatingBase" Level="5">
     <Cost ResourceName="SystemProduction">55</Cost>
     <AIBattleSituations Situation="ProjectileDefense" Mode="Use" Value="1"/>
     <AIBattleSituations Situation="ProjectileWeapon" Mode="Against" Value="1"/>
@@ -74,7 +74,7 @@
     <CategorizedSimulationDescriptors Category="CategoryDefenseHull"> </CategorizedSimulationDescriptors>
   </DefenseModule>
 
-  <DefenseModule Name="ModuleDefenseHullPlating4Unfallen" Family="HullPlatingBase" Level="4">
+  <DefenseModule Name="ModuleDefenseHullPlating4Unfallen" Family="HullPlatingBase" Level="5">
     <Cost ResourceName="SystemProduction">55</Cost>
     <AIBattleSituations Situation="ProjectileDefense" Mode="Use" Value="1"/>
     <AIBattleSituations Situation="ProjectileWeapon" Mode="Against" Value="1"/>


### PR DESCRIPTION
Simple changes to make it so UE and Unfallen plating are not in the obsolete section when making a carrier and having unlocked T5 since they are undoubtedly better than T5 plating